### PR TITLE
Fix CommonSingleType to use TypeScript primitives

### DIFF
--- a/harmony_utils/src/main/ets/entity/constraints.ts
+++ b/harmony_utils/src/main/ets/entity/constraints.ts
@@ -1,7 +1,7 @@
 import { ArrayList, HashMap } from "@kit.ArkTS";
 
 
-export type CommonSingleType = Object | String | Number | Boolean | null | undefined; //通用单个联合类型
+export type CommonSingleType = object | string | number | boolean | null | undefined; //通用单个联合类型
 export type CommonAllType = CommonSingleType | Array<CommonSingleType> | ArrayList<CommonSingleType> | HashMap<CommonSingleType, CommonSingleType>; //通用所有联合类型
 
 

--- a/harmony_utils/src/test/LocalUnit.test.ets
+++ b/harmony_utils/src/test/LocalUnit.test.ets
@@ -1,4 +1,14 @@
 import { describe, beforeAll, beforeEach, afterEach, afterAll, it, expect } from '@ohos/hypium';
+import { CommonSingleType } from '../main/ets/entity/constraints';
+
+type CommonSingleTypeExpected = object | string | number | boolean | null | undefined;
+
+// Compile-time contract: CommonSingleType must be TypeScript primitives, not boxed wrappers.
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type AssertTrue<T extends true> = T;
+type _CommonSingleTypeContract = AssertTrue<Equal<CommonSingleType, CommonSingleTypeExpected>>;
 
 export default function localUnitTest() {
   describe('localUnitTest',() => {
@@ -28,6 +38,13 @@ export default function localUnitTest() {
       // Defines a variety of assertion methods, which are used to declare expected boolean conditions.
       expect(a).assertContain(b);
       expect(a).assertEqual(a);
+    });
+    it('commonSingleTypeUsesPrimitives', 0, () => {
+      const contract: _CommonSingleTypeContract = true;
+      const samples: CommonSingleTypeExpected[] = [{}, 'text', 1, true, null, undefined];
+      const asCommonSingleType: CommonSingleType[] = samples;
+      expect(contract).assertEqual(true);
+      expect(asCommonSingleType.length).assertEqual(6);
     });
   });
 }


### PR DESCRIPTION
## Summary
- CommonSingleType used boxed JS wrappers instead of TypeScript primitives.
- Change to object | string | number | boolean | null | undefined.
- Issue #2 is untouched.

## Test plan
- Compile-time Equal assertion in LocalUnit.test.ets

Fixes #4
