### PR TITLE
Fix ActionSheet compile error by dropping LevelOrder

### DIFF
--- a/harmony_dialog/src/main/ets/model/base/BaseDialogOptions.ets
+++ b/harmony_dialog/src/main/ets/model/base/BaseDialogOptions.ets
@@ -47,6 +47,5 @@ export interface BaseDialogOptions {
   levelMode?: LevelMode; //设置弹窗显示层级。默认值：LevelMode.OVERLAY。当且仅当showInSubWindow属性设置为false时生效。<API15+>
   levelUniqueId?: number; //设置页面级弹窗需要显示的层级下的节点uniqueId。取值范围：大于等于0的数字。当且仅当levelMode属性设置为LevelMode.EMBEDDED时生效。<API15+>
   immersiveMode?: ImmersiveMode; //设置页面内弹窗蒙层效果。默认值：ImmersiveMode.DEFAULT。当且仅当levelMode属性设置为LevelMode.EMBEDDED时生效。<API15+>
-  levelOrder?: LevelOrder; //设置弹窗显示的顺序。默认值：LevelOrder.clamp(0)。不支持动态刷新顺序。<API18+>
 
 }

--- a/harmony_utils/src/main/ets/action/DialogUtil.ets
+++ b/harmony_utils/src/main/ets/action/DialogUtil.ets
@@ -114,8 +114,7 @@ export class DialogUtil {
       hoverModeArea: options.hoverModeArea,
       levelMode: options.levelMode,
       levelUniqueId: options.levelUniqueId,
-      immersiveMode: options.immersiveMode,
-      levelOrder: options.levelOrder
+      immersiveMode: options.immersiveMode
     });
   }
 

--- a/harmony_utils/src/main/ets/entity/DialogOptions.ets
+++ b/harmony_utils/src/main/ets/entity/DialogOptions.ets
@@ -50,7 +50,6 @@ export class DialogOptions {
   levelMode?: LevelMode; //设置弹窗显示层级。默认值：LevelMode.OVERLAY。当且仅当showInSubWindow属性设置为false时生效。<API15+>
   levelUniqueId?: number; //设置页面级弹窗需要显示的层级下的节点uniqueId。取值范围：大于等于0的数字。当且仅当levelMode属性设置为LevelMode.EMBEDDED时生效。<API15+>
   immersiveMode?: ImmersiveMode; //设置页面内弹窗蒙层效果。默认值：ImmersiveMode.DEFAULT。当且仅当levelMode属性设置为LevelMode.EMBEDDED时生效。<API15+>
-  levelOrder?: LevelOrder; //设置弹窗显示的顺序。默认值：LevelOrder.clamp(0)。不支持动态刷新顺序。<API18+>
 
   autoCancel?: boolean; //点击遮障层时，是否关闭弹窗，true表示关闭弹窗。false表示不关闭弹窗。默认值：true
   cancel?: () => void; //点击遮障层关闭dialog时的回调。


### PR DESCRIPTION
Fixes #3

Projects compiling `@pura/harmony-utils` fail with `Cannot find name 'LevelOrder'` and `levelOrder` not existing on `ActionSheetOptions` (API 12 typings expose `levelMode`).

Drop the unsupported `levelOrder` field and pass-through. Keep `levelMode` / `levelUniqueId` / `immersiveMode`.

Signed-off-by: Tony Coder <407243179@qq.com>