### PR TITLE
Fix ToastUtil crash in IME when windowStage is missing

### DIFF
--- a/harmony_utils/src/main/ets/action/ToastUtil.ets
+++ b/harmony_utils/src/main/ets/action/ToastUtil.ets
@@ -16,6 +16,8 @@
 import promptAction from '@ohos.promptAction';
 import { ToastConfig } from '../entity/ToastConfig';
 import { ToastOptions } from '../entity/ToastOptions';
+import { AppUtil } from '../utils/AppUtil';
+import { LogUtil } from '../utils/LogUtil';
 
 
 /**
@@ -43,12 +45,7 @@ export class ToastUtil {
    * @param options (显示时长、距离屏幕底部的位置、是否显示在应用之上)
    */
   static showToast(message: string | Resource, options: ToastOptions = new ToastOptions()) {
-    if (message || (typeof message === 'string' && message.length > 0)) {
-      options = ToastUtil.initToastDefault(options, 0);
-      let toastOptions = options as promptAction.ShowToastOptions;
-      toastOptions.message = message;
-      promptAction.showToast(toastOptions);
-    }
+    ToastUtil.showInner(message, options, 0);
   }
 
 
@@ -58,12 +55,7 @@ export class ToastUtil {
    * @param options (距离屏幕底部的位置、是否显示在应用之上)
    */
   static showShort(message: string | Resource, options: ToastOptions = new ToastOptions()) {
-    if (message || (typeof message === 'string' && message.length > 0)) {
-      options = ToastUtil.initToastDefault(options, 1);
-      let toastOptions = options as promptAction.ShowToastOptions;
-      toastOptions.message = message;
-      promptAction.showToast(toastOptions);
-    }
+    ToastUtil.showInner(message, options, 1);
   }
 
 
@@ -73,11 +65,26 @@ export class ToastUtil {
    * @param options (距离屏幕底部的位置、是否显示在应用之上)
    */
   static showLong(message: string | Resource, options: ToastOptions = new ToastOptions()) {
+    ToastUtil.showInner(message, options, 2);
+  }
+
+  /**
+   * 弹出 toast。Ability 优先走 UIContext；IME/Extension 无主窗口时回退 promptAction.showToast。
+   */
+  private static showInner(message: string | Resource, options: ToastOptions, type: number) {
     if (message || (typeof message === 'string' && message.length > 0)) {
-      options = ToastUtil.initToastDefault(options, 2);
-      let toastOptions = options as promptAction.ShowToastOptions;
-      toastOptions.message = message;
-      promptAction.showToast(toastOptions);
+      try {
+        options = ToastUtil.initToastDefault(options, type);
+        let toastOptions = options as promptAction.ShowToastOptions;
+        toastOptions.message = message;
+        if (options.uiContext) {
+          options.uiContext.getPromptAction().showToast(toastOptions);
+        } else {
+          promptAction.showToast(toastOptions);
+        }
+      } catch (err) {
+        LogUtil.error(err);
+      }
     }
   }
 
@@ -93,6 +100,8 @@ export class ToastUtil {
     } else {
       options.duration = options.duration ?? ToastUtil.defaultConfig.duration;
     }
+    // IME/Extension 无 windowStage，不可走 AppUtil.getUIContext() → getMainWindowSync。
+    options.uiContext = options.uiContext ?? ToastUtil.resolveUIContext();
     options.alignment = options.alignment ?? ToastUtil.defaultConfig.alignment;
     options.bottom = options.bottom ?? ToastUtil.defaultConfig.bottom;
     options.offset = options.offset ?? ToastUtil.defaultConfig.offset;
@@ -106,5 +115,10 @@ export class ToastUtil {
     return options;
   }
 
-
+  /**
+   * 安全获取 UIContext。无 windowStage 或 getMainWindowSync 不可用时返回 undefined。
+   */
+  private static resolveUIContext(): UIContext | undefined {
+    return AppUtil.tryGetUIContext();
+  }
 }

--- a/harmony_utils/src/main/ets/entity/ToastOptions.ets
+++ b/harmony_utils/src/main/ets/entity/ToastOptions.ets
@@ -22,6 +22,7 @@ import { promptAction } from '@kit.ArkUI';
  * since: 2024/08/18
  */
 export class ToastOptions {
+  uiContext?: UIContext; //UI上下文。IME/Extension 无主窗口时可传入组件 getUIContext()。
   duration?: number; //显示时长(1500ms-10000ms)
   alignment?: Alignment; //对齐方式。默认值：undefined，默认底部偏上位置。
   bottom?: string | number; //设置弹窗底部边框距离导航条的高度，ToastShowMode.TOP_MOST模式下，软键盘拉起时，如果bottom值过小，toast要被软键盘遮挡时，会自动避让至距离软键盘80vp处。ToastShowMode.DEFAULT模式下，软键盘拉起时，会上移软键盘的高度。默认值：80vp。说明：当底部没有导航条时，bottom为设置弹窗底部边框距离窗口底部的高度。设置对齐方式alignment后，bottom不生效。

--- a/harmony_utils/src/main/ets/utils/AppUtil.ets
+++ b/harmony_utils/src/main/ets/utils/AppUtil.ets
@@ -92,6 +92,18 @@ export class AppUtil {
   }
 
   /**
+   * 安全获取UIContext。IME/Extension 无 windowStage 时返回 undefined，不抛异常。
+   */
+  static tryGetUIContext(): UIContext | undefined {
+    try {
+      return AppUtil.tryGetMainWindow()?.getUIContext();
+    } catch (err) {
+      LogUtil.error(err);
+      return undefined;
+    }
+  }
+
+  /**
    * 获取WindowStage
    * @returns
    */
@@ -100,10 +112,31 @@ export class AppUtil {
   }
 
   /**
-   * 获取主窗口
+   * 获取主窗口。Ability 路径与原先一致：存在 windowStage 时调用 getMainWindowSync。
+   * IME/Extension 无 windowStage，不可直接解引用 getMainWindowSync。
    */
   static getMainWindow(): window.Window {
-    return AppUtil.getContext().windowStage.getMainWindowSync();
+    const windowStage = AppUtil.getContext().windowStage;
+    if (!windowStage) {
+      throw new Error('AppUtil.getMainWindow: windowStage is undefined');
+    }
+    return windowStage.getMainWindowSync();
+  }
+
+  /**
+   * 安全获取主窗口。IME/Extension 无 windowStage 时返回 undefined，不访问 getMainWindowSync。
+   */
+  static tryGetMainWindow(): window.Window | undefined {
+    try {
+      const windowStage = AppUtil.getContext().windowStage;
+      if (!windowStage) {
+        return undefined;
+      }
+      return windowStage.getMainWindowSync();
+    } catch (err) {
+      LogUtil.error(err);
+      return undefined;
+    }
   }
 
 


### PR DESCRIPTION
Fixes #5

`ToastUtil.showToast` crashed in IME/Extension contexts (`getMainWindowSync of undefined`) because there is no `windowStage`.

Guard the window lookup and fall back to `promptAction.showToast`. Ability path is unchanged when a main window exists. Optional `ToastOptions.uiContext` so an IME can pass `this.getUIContext()`.

Signed-off-by: Tony Coder <407243179@qq.com>